### PR TITLE
Accept object literals

### DIFF
--- a/ecmaScript.js
+++ b/ecmaScript.js
@@ -4,7 +4,7 @@ const { code } = require('./namespaces')
 
 function parseLiteral (node, context) {
   if (node.datatype.equals(code('EcmaScript'))) {
-    return (function () { return eval(node.value) }).call(context) // eslint-disable-line no-eval,no-extra-parens
+    return (function () { return eval(`(${node.value})`) }).call(context) // eslint-disable-line no-eval,no-extra-parens
   }
 
   throw new Error(`Cannot load ecmaScript code from node ${node}`)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "JavaScript native types loader for the Code ontology",
   "main": "index.js",
   "scripts": {
-    "test": "standard && jest"
+    "pretest": "standard",
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/test/ecmaScript.test.js
+++ b/test/ecmaScript.test.js
@@ -33,6 +33,19 @@ describe('ecmaScript loader', () => {
       expect(result).toBe('Hello world')
     })
 
+    test('should accept object literals', () => {
+      // given
+      // eslint-disable-next-line no-template-curly-in-string
+      const node = rdf.literal('{a: (b) => `a${b}c`}', code('EcmaScript'))
+
+      // when
+      const objectLiteral = loader(node, dataset, context)
+
+      // then
+      const result = objectLiteral.a('b')
+      expect(result).toBe('abc')
+    })
+
     test('should throw if node does not have correct datatype', () => {
       // given
       const node = rdf.literal("() => 'nothing'", code('unrecognized'))


### PR DESCRIPTION
It's essentially a noop except when `{` serves as a block opening instead as of an object literal opening.

Blocks aren't the most commonly used feature of JS to say the least, I think it's safe to deny top-level block usage in operations arguments. By denying this we make it possible to have object literals as argument: `eval('{a: 12}') // 12` vs `eval('({a: 12})') // {a: 12}` 

```js
{
  let a = 0

  function foo () {
    {
      if (a) {
          console.log('yes')
      } else {
          console.log('no')
      }
    }
  }

  hey: {
    foo()

    {
        a = 1
    }

    foo()
  }
}

// no
// yes
```