### PR TITLE
Clean up the context terminology in loader parameters

### DIFF
--- a/ecmaScript.js
+++ b/ecmaScript.js
@@ -10,24 +10,24 @@ function parseLiteral (node, context) {
   throw new Error(`Cannot load ecmaScript code from node ${node}`)
 }
 
-function parseNamedNode (node, dataset, { context }) {
+function parseNamedNode (node, dataset, { basePath }) {
   const def = cf(dataset)
   const cfNode = def.node(node)
   const link = cfNode.out(code('link'))
 
   if (link.term && link.term.termType === 'NamedNode') {
-    return iriRequire(link.value, context.basePath)
+    return iriRequire(link.value, basePath)
   }
 
   throw new Error(`Cannot load ecmaScript code from node ${node}`)
 }
 
-function loader (node, dataset, { context }) {
+function loader (node, dataset, options) {
   if (node && node.termType === 'Literal') {
-    return parseLiteral(node, context)
+    return parseLiteral(node, options)
   }
 
-  return parseNamedNode(node, dataset, { context })
+  return parseNamedNode(node, dataset, options)
 }
 
 loader.register = registry => {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "jest": {
     "collectCoverage": true,
     "collectCoverageFrom": [
-      "lib/**"
+      "*.js"
     ]
   }
 }

--- a/test/ecmaScript.test.js
+++ b/test/ecmaScript.test.js
@@ -11,7 +11,6 @@ describe('ecmaScript loader', () => {
   let dataset
   let def
   const context = {
-    basePath: '/some/path'
   }
 
   beforeEach(async () => {

--- a/test/ecmaScript.test.js
+++ b/test/ecmaScript.test.js
@@ -82,4 +82,32 @@ describe('ecmaScript loader', () => {
       expect(typeof str).toBe('string')
     })
   })
+
+  describe('loading from file:', () => {
+    test('should return default export', () => {
+      // given
+      // <operation> code:link <file:foobar>
+      const node = def.node(example('operation'))
+      node.addOut(code('link'), rdf.namedNode('file:foobar'))
+
+      // when
+      const value = loader(node.term, dataset, { context, basePath: __dirname })
+
+      // then
+      expect(value.foo.foo).toBe('bar')
+    })
+
+    test('should return correct export if using hash and dot notation', () => {
+      // given
+      // <operation> code:link <file:foobar.foo>
+      const node = def.node(example('operation'))
+      node.addOut(code('link'), rdf.namedNode('file:foobar#foo.foo'))
+
+      // when
+      const foo = loader(node.term, dataset, { context, basePath: __dirname })
+
+      // then
+      expect(foo).toBe('bar')
+    })
+  })
 })

--- a/test/foobar.js
+++ b/test/foobar.js
@@ -1,0 +1,5 @@
+module.exports = {
+  foo: {
+    foo: 'bar'
+  }
+}


### PR DESCRIPTION
The PR adds tests for loading code referenced with `file:` URIs. 